### PR TITLE
Symfony 3.3.10 changing the way how the mapping is readed urlFrom -> url_from

### DIFF
--- a/Resources/config/doctrine/Map.orm.yml
+++ b/Resources/config/doctrine/Map.orm.yml
@@ -3,7 +3,7 @@ Astina\Bundle\RedirectManagerBundle\Entity\Map:
     table: armb_redirect_map
     repositoryClass: Astina\Bundle\RedirectManagerBundle\Entity\MapRepository
     uniqueConstraints:
-        host_urlFrom: { columns: [host, url_from] }
+        host_urlFrom: { columns: [host, urlFrom] }
     fields:
         id:
             type: integer
@@ -11,6 +11,7 @@ Astina\Bundle\RedirectManagerBundle\Entity\Map:
             generator:
                 strategy: AUTO
         host:
+            column: host
             type: string
             length: 255
             nullable: true
@@ -21,6 +22,7 @@ Astina\Bundle\RedirectManagerBundle\Entity\Map:
             type: boolean
             nullable: true
         urlFrom:
+            column: urlFrom
             type: string
             length: 255
         urlFromIsRegexPattern:


### PR DESCRIPTION
Got an error during the usage of
`php bin/console doctrine:schema:update --force` 
the column url_form doesn't exists.

Version of symfony 3.3.10