### PR TITLE
Urldecode on RequestUri

### DIFF
--- a/Redirect/Redirect.php
+++ b/Redirect/Redirect.php
@@ -65,9 +65,9 @@ class Redirect
     {
         $urlFrom = $this->map->getUrlFrom();
         if ($this->isAbsoluteUrl($urlFrom)) {
-            $matchUri = $this->request->getSchemeAndHttpHost() . $this->request->getRequestUri();
+            $matchUri = $this->request->getSchemeAndHttpHost() . urldecode($this->request->getRequestUri());
         } else {
-            $matchUri = $this->request->getRequestUri();
+            $matchUri = urldecode($this->request->getRequestUri());
         }
 
         if (!$this->map->getUrlFromIsRegexPattern()) {

--- a/Redirect/Redirect.php
+++ b/Redirect/Redirect.php
@@ -64,10 +64,11 @@ class Redirect
     public function matchesPath()
     {
         $urlFrom = $this->map->getUrlFrom();
+        $requestUri = urldecode($this->request->getRequestUri());
         if ($this->isAbsoluteUrl($urlFrom)) {
-            $matchUri = $this->request->getSchemeAndHttpHost() . urldecode($this->request->getRequestUri());
+            $matchUri = $this->request->getSchemeAndHttpHost() . $requestUri;
         } else {
-            $matchUri = urldecode($this->request->getRequestUri());
+            $matchUri = $requestUri;
         }
 
         if (!$this->map->getUrlFromIsRegexPattern()) {

--- a/Redirect/RedirectFinder.php
+++ b/Redirect/RedirectFinder.php
@@ -38,8 +38,9 @@ class RedirectFinder implements RedirectFinderInterface
      */
     public function findRedirect(Request $request)
     {
-        $path = str_replace($request->getBaseUrl(), '/', $request->getRequestUri());
-        $url = $request->getSchemeAndHttpHost() . $request->getRequestUri();
+        $requestUri = urldecode($request->getRequestUri());
+        $path = str_replace($request->getBaseUrl(), '/', $requestUri);
+        $url = $request->getSchemeAndHttpHost() . $requestUri;
 
         // find possible candidates for redirection
         /** @var MapRepository $repo */


### PR DESCRIPTION
RequestUri return the url encoded but In the DB it is saved not encode.
To make the comparison accurate, we need to urldecode the RequestUri

This fix the no-working redirect containing german char like äöü